### PR TITLE
document and fragment allow conditionals and nested arrays of filter&transformer pairs

### DIFF
--- a/src/me/raynes/laser.clj
+++ b/src/me/raynes/laser.clj
@@ -347,7 +347,7 @@
 
 ;; High level
 
-(defn ffns [fns]
+(defn ^:private ffns [fns]
   "Filters the fns into partitions of 2"
   (partition 2 (filter fn? (flatten fns))))
 

--- a/src/me/raynes/laser.clj
+++ b/src/me/raynes/laser.clj
@@ -347,13 +347,17 @@
 
 ;; High level
 
+(defn ffns [fns]
+  "Filters the fns into partitions of 2"
+  (partition 2 (filter fn? (flatten fns))))
+
 (defn document
   "Transform an HTML document. Use this for any top-level transformation.
    It expects a full HTML document (complete with <html> and <head>) and
    makes it one if it doesn't get one. Takes HTML parsed by the parse-html
    function."
   [s & fns]
-  (to-html (traverse-zip (partition 2 fns) (lzip/leftmost-descendant s))))
+  (to-html (traverse-zip (ffns fns) (lzip/leftmost-descendant s))))
 
 (defn fragment
   "Transform an HTML fragment. Use document for transforming full HTML
@@ -362,7 +366,7 @@
    composing fragments faster. You can call to-html on the output to get
    HTML."
   [s & fns]
-  (let [pairs (partition 2 fns)]
+  (let [pairs (ffns fns)]
     (reduce #(if (sequential? %2)
                (into % %2)
                (conj % %2))

--- a/test/me/raynes/laser_test.clj
+++ b/test/me/raynes/laser_test.clj
@@ -177,6 +177,26 @@
    (l/element= :a) (fn [node] [(element :span) node])) => [(element :span) (element :a)
                                                            (element :span) (element :a)])
 
+(fact "document and fragment allow conditionals and nested arrays of filter&transformer pairs"
+  (l/fragment
+    (l/parse-fragment "<html><div></div></html>")
+
+    ; this one will return nil, which will be filtered out
+    (when false
+      (l/element= :div ) (l/add-class "not-executed"))
+
+    ; allow nested filter&transformer pairs
+    [
+      (l/element= :div ) (l/add-class "c1")
+      (l/element= :div ) (l/add-class "c2")
+      [
+        [(l/element= :div ) (l/add-class "c3")]
+        ]
+      ]
+
+    ) => [{:attrs {:class "c1 c2 c3"}, :content nil, :tag :div, :type :element}]
+  )
+
 (fact "nils are treated as removals and replaced as empty strings."
   (l/fragment-to-html
              (l/fragment (l/parse-fragment "<a></a>")


### PR DESCRIPTION
Hi Anthony. First, let me thank you for this great library.

I just started to use it a few days ago and found that I needed more flexibility when defining my fragment and document bodies, so I made those modifications.

Maybe you find the feature useful enough to add it into the main branch.

Regards
