### PR TITLE
Updated docstring

### DIFF
--- a/src/me/raynes/laser/zip.clj
+++ b/src/me/raynes/laser/zip.clj
@@ -42,8 +42,11 @@
   (contains? (meta obj) :zip/make-node))
 
 (defn zip
-  "Get a zipper suitable for passing to fragment, document, or select, from
-   a hickory node or a sequence of hickory nodes."
+  "Given a hickory node, returns a zipper. Given a sequence of hickory
+   nodes, returns a sequence of zippers. Zippers are suitable for
+   passing to fragment, document, or select.
+
+   Given a zipper it will return the zipper."
   [n]
   (cond
    (zipper? n) n


### PR DESCRIPTION
The docstring implied that the return value was always suitable
for passing to select, etc., which is not true if you pass a
sequence of nodes. Tried to make the docstring both accurate and
clear.
